### PR TITLE
Adding initial code of tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Project specific
+# ================
+output

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+build:
+	mkdir -p output && cp source/garud.sh output/garud && chmod +rwx output/garud

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# expect_runner
-Expect runner will discover `expect` tests and it will run them one by one.
+# Garud 🦅
+
+## Description
+
+Garud is a runner for [Expect][expect] tests. The took discovers expect tests
+from the directory and it will run them one by one. When any test fails, it
+stops the ongoing testing procedure.
+
+
+## Build
+
+```make build```
+
+Above command will generate build at `output` directory.
+
+
+[expect]: https://wiki.tcl-lang.org/page/Expect

--- a/source/garud.sh
+++ b/source/garud.sh
@@ -1,0 +1,28 @@
+#! /bin/sh
+
+help () {
+  echo "Usage"
+  echo ""
+  echo "    garud [test-cases-dir]"
+  echo ""
+  echo "Arguments"
+  echo "    test-cases-dir: The directory where all expect test cases are present"
+}
+
+if [ $# -eq 1 ]
+then
+  TARGET_DIR=$1
+  FILE_EXTENSION="expect"
+
+  for SCRIPT in `find $TARGET_DIR -name *.$FILE_EXTENSION`
+  do
+    echo "## Executing tests written in $SCRIPT"
+    echo ""
+    expect $SCRIPT
+    echo ""
+    echo "## Ended executing $SCRIPT"
+    echo ""
+  done
+else
+  help
+fi


### PR DESCRIPTION
This tool is limited to only find '*.expect' files at present. The tool
will execute all the `*.expect` files one by one. It will break if any
test is failed.

Usage:

`garud example_tests_dir`